### PR TITLE
fix(destroy workflow):  Remove deleteToipcs from the destroy workflow

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Destroy
         run: run destroy --stage $STAGE_NAME --verify false
 
-      - name: Delete topics
-        run: run deleteTopics --stage $STAGE_NAME
-
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         if: env.SLACK_WEBHOOK != '' && failure()


### PR DESCRIPTION
## Purpose

Fixes a bug with the destroy workflow.  The destroy workflow should not try to delete topics, as there are no topics created by this project

#### Linked Issues to Close

None

## Approach

Remove deleteToipcs call from the destroy workflow

## Learning

None

## Assorted Notes/Considerations

None

