### PR TITLE
feat(ecr): Use ECR w/fallback to prevent rate limiting

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -60,6 +60,7 @@ custom:
       - production
   vpc: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/vpc, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/vpc}
   brokerString: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/brokerString, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/brokerString}
+  connectImage: ${ssm:/aws/reference/secretsmanager/ecr/images/${self:custom.project}/${self:service}, "confluentinc/cp-kafka-connect:6.0.9"}
   scripts:
     hooks:
       deploy:finalize: |
@@ -240,12 +241,16 @@ resources:
                   Action:
                     - lambda:InvokeFunction
                   Resource: !GetAtt SinkSeatoolDataLambdaFunction.Arn
+                - Effect: Allow
+                  Action:
+                    - ecr:BatchGetImage
+                  Resource: !Sub "arn:aws:ecr:${self:provider.region}:${AWS::AccountId}:repository/*"
     KafkaConnectWorkerTaskDefinition:
       Type: "AWS::ECS::TaskDefinition"
       Properties:
         ContainerDefinitions:
           - Name: connect
-            Image: "confluentinc/cp-kafka-connect:6.0.9"
+            Image: ${self:custom.connectImage}
             Memory: 4096
             Cpu: 2048
             Command:


### PR DESCRIPTION
## Purpose

This change is to pull specific docker images from ecr private repo instead of directly from docker hub, which can cause issues with rate limiting. 

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-21947

## Approach

Currently we rely on a small handfull of docker images when defining our fargate tasks for kafka connectors. As more ephemeral branches are created and more projects are stored within this aws account we are often reaching a rate limit on pulling docker images causing developer slow-down.

To avoid this, we have added these eight (at the time of writing) images to a private ecr repo within the development environment of the bigmac account. These image uri's are available via secretsmanager variables with the default value being the image located within docker hub. This will be the fallback if any secret is not available, which will be the case in val and prod. As they are on a different account they are not affected by the rate limiting so using private images is unnecessary.

> confluentinc/ksqldb-server:0.26.0
> confluentinc/cp-kafka-connect:6.0.9
> confluentinc/cp-kafka:7.0.3
> confluentinc/cp-kafka-connect:5.5.10
> confluentinc/cp-kafka-connect:5.5.2
> confluentinc/cp-kafka-connect:6.0.9
> confluentinc/ksqldb-server:0.26.0
> confluentinc/cp-kafka-connect:6.0.9

## Learning

There was some consideration given to adding a github workflow to check if these repos exist, and pull and add if they didn't. this direction seemed problematic as developers often deploy without using github actions, etc.

There was additional consideration given to a separate service that would check, pull, and push images to a private repo and output the image uri's across services. The long term maintenance of this solution feels problematic and costly.  Ultimately manual addition of images with responsible fall back options was chosen for brevity, cost effectiveness and maintainability.