### PR TITLE
Hotfix - Encrypt SNS with KMS

### DIFF
--- a/src/services/alerts/serverless.yml
+++ b/src/services/alerts/serverless.yml
@@ -31,6 +31,29 @@ resources:
       Type: "AWS::SNS::Topic"
       Properties:
         TopicName: ECSTaskFailure-${self:service}-${sls:stage}
+        KmsMasterKeyId: !Ref KmsKeyForSns
+
+    KmsKeyForSns:
+      Type: AWS::KMS::Key
+      Properties:
+        EnableKeyRotation: "true"
+        KeyPolicy:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: Allow access for Root User
+              Effect: Allow
+              Principal:
+                AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+              Action: "kms:*"
+              Resource: "*"
+            - Sid: Allow access for Key User (SNS Service Principal)
+              Effect: Allow
+              Principal:
+                Service: "sns.amazonaws.com"
+              Action:
+                - "kms:GenerateDataKey"
+                - "kms:Decrypt"
+              Resource: "*"
 
     EventBridgeToToSnsPolicy:
       Type: AWS::SNS::TopicPolicy


### PR DESCRIPTION
This is a hotfix to val

The SNS topic had a security hub finding, where it was unencrypted.  This was fixed on master, but needs to promote to val and production.  Since master is currently unable to promote as-is until next week, this is to ship just the SNS KMS fix, so we can clear the SecHub findings