### PR TITLE
fix(silence warn): silence offset timed out warning

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -428,6 +428,8 @@ resources:
                   ${self:custom.brokerString}
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
                 Value: SSL
+              - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
+                Value: "30000" # default 5000 (5s)
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -278,7 +278,7 @@ resources:
         LogGroupName:
           Ref: "KafkaConnectWorkerLogGroup"
         FilterName: ConnectorLogsWarnCount
-        FilterPattern: "WARN"
+        FilterPattern: '{($.message = "WARN") && ($.message != /.*Commit of offsets timed out.*/)}'
         MetricTransformations:
           - MetricValue: "1"
             DefaultValue: "0"
@@ -428,8 +428,8 @@ resources:
                   ${self:custom.brokerString}
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
                 Value: SSL
-              - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
-                Value: "60000" # default 5000 (5s)
+              # - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
+              #   Value: "60000" # default 5000 (5s)
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -429,7 +429,7 @@ resources:
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
                 Value: SSL
               - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
-                Value: "1000" # default 5000 (5s)
+                Value: "60000" # default 5000 (5s)
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -278,7 +278,7 @@ resources:
         LogGroupName:
           Ref: "KafkaConnectWorkerLogGroup"
         FilterName: ConnectorLogsWarnCount
-        FilterPattern: '{($.message = "WARN") && ($.message != /.*Commit of offsets timed out.*/)}'
+        FilterPattern: WARN -"Commit of offsets timed out"
         MetricTransformations:
           - MetricValue: "1"
             DefaultValue: "0"

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -429,7 +429,7 @@ resources:
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
                 Value: SSL
               - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
-                Value: "30000" # default 5000 (5s)
+                Value: "1000" # default 5000 (5s)
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -428,8 +428,6 @@ resources:
                   ${self:custom.brokerString}
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
                 Value: SSL
-              # - Name: CONNECT_CONSUMER_OFFSET_FLUSH_TIMEOUT_MS
-              #   Value: "60000" # default 5000 (5s)
             LogConfiguration:
               LogDriver: awslogs
               Options:


### PR DESCRIPTION
## Purpose

We are receiving a large number of warnings in production:

```
WARN WorkerSinkTask{id=compare-connector-production.lambda.seatoolData-0} Commit of offsets timed out (org.apache.kafka.connect.runtime.WorkerSinkTask)
```

Attempts were made to increase the offset flush timeout 
docs: https://docs.confluent.io/platform/current/installation/configuration/connect/index.html#offset-flush-timeout-ms

but the warnings persisted. This change adjusts the filter to exclude logs with the phrase "Commit of offsets timed out" from triggering an unhealthy metric.

We only adjusted the filter parameters bc we still want to capture warnings that are unrelated to this particular issue.

A ticket to investigate the root cause has been created here: https://qmacbis.atlassian.net/browse/OY2-23709

#### Linked Issues to Close

N/A
