### PR TITLE
[DO NOT MERGE] - feat(iam): Changes to support bigmac IAM auth

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -63,6 +63,11 @@ provider:
             - secretsmanager:ListSecrets
           Resource:
             - "*"
+        - Effect: "Allow"
+          Action:
+            - sts:AssumeRole
+          Resource:
+            - ${self:custom.bigmacRoleArn}
 
 custom:
   project: ${env:PROJECT}
@@ -74,6 +79,7 @@ custom:
   vpc: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/vpc, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/vpc}
   brokerString: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/brokerString, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/brokerString}
   connectImage: ${ssm:/aws/reference/secretsmanager/ecr/images/${self:custom.project}/${self:service}, "confluentinc/cp-kafka-connect:6.0.9"}
+  bigmacRoleArn: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/bigmacRoleArn, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/bigmacRoleArn}
   scripts:
     hooks:
       deploy:finalize: |
@@ -363,6 +369,11 @@ resources:
                   Action:
                     - ecr:BatchGetImage
                   Resource: !Sub "arn:aws:ecr:${self:provider.region}:${AWS::AccountId}:repository/*"
+                - Effect: "Allow"
+                  Action:
+                    - sts:AssumeRole
+                  Resource:
+                    - ${self:custom.bigmacRoleArn}
     KafkaConnectWorkerTaskDefinition:
       Type: "AWS::ECS::TaskDefinition"
       Properties:
@@ -384,6 +395,7 @@ resources:
                   source /home/appuser/.bashrc
                   export CONNECT_REST_HOST_NAME=$ENI_IP &&
                   export CONNECT_REST_ADVERTISED_HOST_NAME=$ENI_IP &&
+                  curl -k -SL -o /usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar "https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.3/aws-msk-iam-auth-1.1.3-all.jar" &&
                   curl -k -SL -o /etc/kafka-connect/jars/kafka-connect-lambda-1.2.2.jar "https://github.com/Nordstrom/kafka-connect-lambda/releases/download/v1.2.2/kafka-connect-lambda-1.2.2.jar" &&
                   chmod +x /etc/kafka-connect/jaras/kafka-connect-lambda-1.2.2.jar
                   /etc/confluent/docker/run
@@ -414,20 +426,40 @@ resources:
                 Value: org.apache.kafka.connect.json.JsonConverter
               - Name: CONNECT_PLUGIN_PATH
                 Value: /usr/share/java,/usr/local/share/kafka/plugins
+              - Name: CLASSPATH
+                Value: /etc/kafka-connect/jars/*:/usr/share/java/cp-base-new/aws-msk-iam-auth-1.1.3-all.jar
               - Name: CONNECT_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
               # Producer/Consumer configs below
               # Thank you to https://github.com/confluentinc/kafka-connect-jdbc/issues/161
               - Name: CONNECT_PRODUCER_BOOTSTRAP_SERVERS
                 Value: >-
                   ${self:custom.brokerString}
               - Name: CONNECT_PRODUCER_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_PRODUCER_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_PRODUCER_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_PRODUCER_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandle
               - Name: CONNECT_CONSUMER_BOOTSTRAP_SERVERS
                 Value: >-
                   ${self:custom.brokerString}
               - Name: CONNECT_CONSUMER_SECURITY_PROTOCOL
-                Value: SSL
+                Value: SASL_SSL
+              - Name: CONNECT_CONSUMER_SASL_MECHANISM
+                Value: AWS_MSK_IAM
+              - Name: CONNECT_CONSUMER_SASL_JAAS_CONFIG
+                Value: software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="${self:custom.bigmacRoleArn}";
+              - Name: CONNECT_CONSUMER_SASL_CLIENT_CALLBACK_HANDLER_CLASS
+                Value: software.amazon.msk.auth.iam.IAMClientCallbackHandler
             LogConfiguration:
               LogDriver: awslogs
               Options:


### PR DESCRIPTION
## Purpose

This changeset represents what's needed to preserve all project functionality when Bigmac IAM Auth is enabled.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23457

## Approach

The connector ECS task was modified to accomidate IAM. An msk iam auth jar is installed as part of the bootstrapping process. The environment variables passed to the container are also expanded and modified, with the appropriate config for IAM auth. In particular, in these env variables is where we say "assume this role".

## Assorted Notes/Considerations/Learning

most of these changes were borrowed from the implementation [here](https://github.com/Enterprise-CMCS/mmdl-connectors/pull/100)
