### PR TITLE
fix(appian-alert): adjust email template for no matches for appian alerts

### DIFF
--- a/src/services/compare-appian/handlers/sendNoMatchAlert.ts
+++ b/src/services/compare-appian/handlers/sendNoMatchAlert.ts
@@ -48,7 +48,11 @@ exports.handler = async function (
   const isUrgent = secSinceAppianSubmitted >= 432000; // Five days in secs
 
   // Build the email from the template:
-  const emailContent = getEmailContent({ id, isUrgent });
+  const emailContent = getEmailContent({
+    id,
+    isUrgent,
+    seatoolSubdomain: process.env.seatoolSubdomain,
+  });
   const emailBody = Libs.getEmailBody(emailContent);
   const subjectText = `${id} - ACTION REQUIRED - No matching record in SEA Tool`;
 

--- a/src/services/compare-appian/handlers/utils/getEmailContent.ts
+++ b/src/services/compare-appian/handlers/utils/getEmailContent.ts
@@ -1,9 +1,11 @@
 export const getEmailContent = ({
   id,
   isUrgent,
+  seatoolSubdomain = "sea",
 }: {
   id: string;
   isUrgent: boolean;
+  seatoolSubdomain?: string;
 }) => {
   const htmlData = `
     <html lang='en'>
@@ -16,16 +18,16 @@ export const getEmailContent = ({
         <center>
         <h2>This is ${
           isUrgent ? "an urgent" : "a"
-        } reminder that there's no matching record in SEA Tool for ${id}.</h2>
+        } reminder that there's no matching record in <a href="https://${seatoolSubdomain}.cms.gov/" style="text-decoration:none" target="_blank">SEA Tool</a> for ${id}.</h2>
         <br>
         <p>Either a record wasn't created in SEA Tool, or the SPA ID in Appian and SEA Tool don't match.</p>
         ${
           isUrgent
-            ? "<em>Failure to address this could lead to critical delay in the review process and a deemed aproved SPA.</em>"
+            ? "<em>Failure to address this could lead to critical delays in the review process and a deemed approved SPA action.</em>"
             : ""
         }
         <br>
-        <div style=' background-color: rgb(22, 82, 150); width: 580px; padding: 20px; margin: 20px; color: white;'> if you have any questions, please contact the help desk at <a href="mailto:SEATool_helpDesk@cms.hhs.org" style="color:#ffffff;">SEATool_helpDesk@cms.hhs.org</a> </div>
+        <div style=' background-color: rgb(22, 82, 150); padding: 20px; margin: 20px; color: white;'>Please respond to this email address, <a href="mailto:SEATool_HelpDesk@cms.hhs.gov" style="color:#ffffff;">SEATool_HelpDesk@cms.hhs.gov</a>, if you have any further questions. </div>
         </center>
       </body>
     </html>

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -88,24 +88,28 @@ params:
     tempWaitSec: 172800 # 2 days
     sinceSubmissionChoiceSec: 345600 # 4 days
     recordAgeChoiceSec: 17366000 # 201 days
+    seatoolSubdomain: seadev
     workflowsStatus: ON
   val:
     initialWaitSec: 86400
     tempWaitSec: 172800
     sinceSubmissionChoiceSec: 345600
     recordAgeChoiceSec: 17366000
+    seatoolSubdomain: seaval
     workflowsStatus: OFF
   production:
     initialWaitSec: 86400
     tempWaitSec: 172800
     sinceSubmissionChoiceSec: 345600
     recordAgeChoiceSec: 17366000
+    seatoolSubdomain: sea
     workflowsStatus: OFF
   default:
     initialWaitSec: 2
     tempWaitSec: 43200 # 12 hours
     sinceSubmissionChoiceSec: 3
     recordAgeChoiceSec: 17366000 # 201 days
+    seatoolSubdomain: seadev
     workflowsStatus: ON
 
 custom:
@@ -170,6 +174,7 @@ functions:
       stage: ${sls:stage}
       sesLogGroupName: ${param:sesLogGroupName}
       errorsTopicArn: ${param:errorsTopicArn}
+      seatoolSubdomain: ${param:seatoolSubdomain}
   getAppianData:
     handler: handlers/getAppianData.handler
     environment:


### PR DESCRIPTION
## Purpose
Add missing logic to appian-alerting sendNoMatch email alert. We will still need logic for mismatched submission dates which will be implemented in another ticket.

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23321

## Approach
Followed this figma logic:
https://www.figma.com/file/PLwoWX22Bpisgk0GBIsrZE/Appian-alerts?type=design&node-id=1-212&t=hH5X3TquwaqIQSie-0
