### PR TITLE
fix(workflow-starter): catch existing execution error

### DIFF
--- a/src/services/compare-appian/handlers/workflowStarter.ts
+++ b/src/services/compare-appian/handlers/workflowStarter.ts
@@ -60,8 +60,16 @@ exports.handler = async function (event: {
         "Result from starting step function command",
         JSON.stringify(result, null, 2)
       );
-    } catch (e) {
-      await trackError(e);
+    } catch (e: any) {
+      if (e.name === "ExecutionAlreadyExists") {
+        console.log(
+          `Execution already exists for key: ${JSON.stringify(
+            key
+          )}. Taking no action.`
+        );
+      } else {
+        await trackError(e);
+      }
     } finally {
       console.log("finally");
     }


### PR DESCRIPTION
## Purpose

Adjusting the error handling to account for executions already existing, similarly to the compare-mmdl workflow.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-24512
