### PR TITLE
feat(prod-workflow): add step function workflow not in ignored state for production

### DIFF
--- a/src/services/compare-appian/handlers/sendNoMatchAlert.ts
+++ b/src/services/compare-appian/handlers/sendNoMatchAlert.ts
@@ -103,9 +103,7 @@ exports.handler = async function (
         ToAddresses,
       });
 
-      console.log("before alert");
       if (!isIgnoredState) {
-        console.log("running alert");
         await Libs.sendAlert(emailParams);
       }
 

--- a/src/services/compare-appian/handlers/sendNoMatchAlert.ts
+++ b/src/services/compare-appian/handlers/sendNoMatchAlert.ts
@@ -103,7 +103,9 @@ exports.handler = async function (
         ToAddresses,
       });
 
+      console.log("before alert");
       if (!isIgnoredState) {
+        console.log("running alert");
         await Libs.sendAlert(emailParams);
       }
 

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -1,6 +1,7 @@
 import * as Libs from "../../../libs";
 import * as Types from "../../../types";
 import { getItem } from "../../../libs";
+import { getIsIgnoredState } from "./utils/getIsIgnoredState";
 
 function formatDate(dateMs: number) {
   return new Date(dateMs).toLocaleString("en-US", {
@@ -19,6 +20,7 @@ const convertMsToDate = (milliseconds?: number) => {
 
 function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
   return data.map((i) => {
+    const isIgnoredState = getIsIgnoredState(i);
     return {
       "SPA ID": i.SPA_ID,
       "Submission Date":
@@ -29,6 +31,7 @@ function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
       "Seatool Signed Date": i.seatoolSubmissionDate
         ? formatDate(Number(i.seatoolSubmissionDate))
         : "N/A",
+      "Test State": isIgnoredState || false,
       // "Records Match": i.match || false,
     };
   });

--- a/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
+++ b/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
@@ -1,0 +1,22 @@
+import * as Types from "../../../../types";
+
+export const getIsIgnoredState = (
+  data: Types.AppianReportData | Types.ReportData
+) => {
+  const ignoredStates = process.env.ignoredStates;
+  if (!ignoredStates) {
+    return false;
+  }
+  const testStatesList: string[] = [];
+  ignoredStates
+    .split(",")
+    .forEach((state: string) => testStatesList.push(state));
+  const isIgnoredState =
+    testStatesList.indexOf(data.SPA_ID.slice(0, 2).toUpperCase()) > -1;
+  if (isIgnoredState) {
+    console.log("IGNORED STATE - NO ALERTS WILL BE SENT");
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -108,7 +108,7 @@ params:
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: seadev
     workflowsStatus: ON
-    ignoredStates: N/A
+    ignoredStates: ZZ,ZT
     skipWait: true
 
 custom:

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -97,7 +97,7 @@ params:
     sinceSubmissionChoiceSec: 259200
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: sea
-    workflowsStatus: OFF
+    workflowsStatus: ON
     skipWait: false
   default:
     tempWaitSec: 3600 # 1 hour

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -107,7 +107,7 @@ params:
     sinceSubmissionChoiceSec: 3
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: seadev
-    workflowsStatus: OFF
+    workflowsStatus: ON
     ignoredStates: N/A
     skipWait: true
 

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -107,8 +107,8 @@ params:
     sinceSubmissionChoiceSec: 3
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: seadev
-    workflowsStatus: ON
-    ignoredStates: ZZ,ZT
+    workflowsStatus: OFF
+    ignoredStates: N/A
     skipWait: true
 
 custom:

--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -84,6 +84,7 @@ params:
     recordAgeChoiceSec: 17366000 # 201 days
     seatoolSubdomain: seadev
     workflowsStatus: ON
+    ignoredStates: N/A
     skipWait: false
   val:
     tempWaitSec: 172800
@@ -91,6 +92,7 @@ params:
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: seaval
     workflowsStatus: ON
+    ignoredStates: N/A
     skipWait: false
   production:
     tempWaitSec: 172800
@@ -98,6 +100,7 @@ params:
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: sea
     workflowsStatus: ON
+    ignoredStates: ZZ,ZT
     skipWait: false
   default:
     tempWaitSec: 3600 # 1 hour
@@ -105,6 +108,7 @@ params:
     recordAgeChoiceSec: 17366000
     seatoolSubdomain: seadev
     workflowsStatus: OFF
+    ignoredStates: N/A
     skipWait: true
 
 custom:
@@ -139,6 +143,7 @@ functions:
       seatoolTableName: ${param:seatoolTableName}
       errorsTopicArn: ${param:errorsTopicArn}
       appianTableName: ${param:appianTableName}
+      ignoredStates: ${param:ignoredStates}
   compare:
     handler: handlers/compare.handler
     environment:
@@ -165,6 +170,7 @@ functions:
       sesLogGroupName: ${param:sesLogGroupName}
       errorsTopicArn: ${param:errorsTopicArn}
       seatoolSubdomain: ${param:seatoolSubdomain}
+      ignoredStates: ${param:ignoredStates}
   getAppianData:
     handler: handlers/getAppianData.handler
     environment:


### PR DESCRIPTION
## Purpose
Add logic to fire step functions for production when we are ready and added logic to filter out ZZ and ZT records

## Assorted Notes/Considerations/Learning
- Appian will propagate changes to production Thursday night
- We will add soft launch emails before propagating to production
