### PR TITLE
Fix(reports): fix issue when spa_id is null in appian reporting

### DIFF
--- a/src/services/compare-appian/handlers/getAppianData.ts
+++ b/src/services/compare-appian/handlers/getAppianData.ts
@@ -26,6 +26,7 @@ exports.handler = async function (
 
     data.appianRecord = appianRecord as Types.AppianRecord;
     data.SPA_ID = appianRecord.payload?.SPA_ID;
+    data.SPA_PCKG_ID = appianRecord.payload?.SPA_PCKG_ID;
 
     /* Checking if the appian record was submitted within the last 200 days. */
     const submissionDate = appianRecord.payload?.SBMSSN_DATE;

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -31,19 +31,23 @@ function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
       isIgnoredState
     );
 
-    return {
-      "SPA ID": i.SPA_ID,
-      "Submission Date":
-        i.SBMSSN_DATE && convertMsToDate(i.SBMSSN_DATE)
-          ? formatDate(Number(i.SBMSSN_DATE))
-          : "",
-      "Seatool Record Exist": i.seatoolExist,
-      "Seatool Signed Date": i.seatoolSubmissionDate
-        ? formatDate(Number(i.seatoolSubmissionDate))
-        : "N/A",
-      "Test State": isIgnoredState || false,
-      // "Records Match": i.match || false,
-    };
+    if (i.SPA_ID) {
+      return {
+        "SPA ID": i.SPA_ID,
+        "Submission Date":
+          i.SBMSSN_DATE && convertMsToDate(i.SBMSSN_DATE)
+            ? formatDate(Number(i.SBMSSN_DATE))
+            : "",
+        "Seatool Record Exist": i.seatoolExist,
+        "Seatool Signed Date": i.seatoolSubmissionDate
+          ? formatDate(Number(i.seatoolSubmissionDate))
+          : "N/A",
+        "Test State": isIgnoredState || false,
+        // "Records Match": i.match || false,
+      };
+    } else {
+      return {};
+    }
   });
 }
 

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -86,15 +86,20 @@ exports.handler = async function (event: { recipient: string; days: number }) {
       TableName: process.env.appianTableName,
     });
 
+    console.log("appianRecords", appianRecords);
+
     const recordsWithPayload = appianRecords?.map((record) => {
       return record.payload;
     });
+    console.log("recordsWithPayload", recordsWithPayload);
 
     const relevantAppianRecords = (
       recordsWithPayload as Types.AppianFormField[]
     ).filter((record) => {
       return record && record.SBMSSN_DATE && record.SBMSSN_DATE >= epochTime;
     });
+
+    console.log("relevantAppianRecords", relevantAppianRecords);
 
     if (!relevantAppianRecords) {
       throw "No relevant appain records to show. Check your days value.";
@@ -104,7 +109,10 @@ exports.handler = async function (event: { recipient: string; days: number }) {
       relevantAppianRecords.map((record) => addSeatoolExists(record))
     );
 
+    console.log("results", results);
+
     const reportDataJson = formatReportData(results);
+    console.log("reportDataJson", reportDataJson);
     const csv = Libs.getCsvFromJson(reportDataJson);
     const mailOptions = getMailOptionsWithAttachment({
       recipient,

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -20,7 +20,16 @@ const convertMsToDate = (milliseconds?: number) => {
 
 function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
   return data.map((i) => {
+    console.log("before ignore state");
     const isIgnoredState = getIsIgnoredState(i);
+    console.log(
+      "after ignore state",
+      i.SPA_ID,
+      i.SBMSSN_DATE,
+      i.seatoolExist,
+      i.seatoolSubmissionDate,
+      isIgnoredState
+    );
     return {
       "SPA ID": i.SPA_ID,
       "Submission Date":

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -140,7 +140,7 @@ async function addSeatoolExists(
     return {
       ...record,
       seatoolExist: true,
-      seatoolSubmissionDate: seatoolItem.STATE_PLAN.SUBMISSION_DATE,
+      seatoolSubmissionDate: seatoolItem.SUBMISSION_DATE,
     };
   }
   return {

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -128,6 +128,7 @@ exports.handler = async function (event: { recipient: string; days: number }) {
 async function addSeatoolExists(
   record: Types.AppianFormField
 ): Promise<Types.ReportData> {
+  console.log("before get item", record.SPA_ID, process.env.seatoolTableName);
   const seatoolItem = await getItem({
     tableName: process.env.seatoolTableName || "",
     key: {
@@ -140,7 +141,7 @@ async function addSeatoolExists(
     return {
       ...record,
       seatoolExist: true,
-      seatoolSubmissionDate: seatoolItem.SUBMISSION_DATE,
+      seatoolSubmissionDate: seatoolItem.STATE_PLAN.SUBMISSION_DATE,
     };
   }
   return {

--- a/src/services/compare-appian/handlers/sendReport.ts
+++ b/src/services/compare-appian/handlers/sendReport.ts
@@ -20,7 +20,7 @@ const convertMsToDate = (milliseconds?: number) => {
 
 function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
   return data.map((i) => {
-    console.log("before ignore state");
+    console.log("before ignore state", i.SPA_ID);
     const isIgnoredState = getIsIgnoredState(i);
     console.log(
       "after ignore state",
@@ -30,6 +30,7 @@ function formatReportData(data: Types.ReportData[]): Types.CSVData[] {
       i.seatoolSubmissionDate,
       isIgnoredState
     );
+
     return {
       "SPA ID": i.SPA_ID,
       "Submission Date":

--- a/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
+++ b/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
@@ -4,7 +4,7 @@ export const getIsIgnoredState = (
   data: Types.AppianReportData | Types.ReportData
 ) => {
   const ignoredStates = process.env.ignoredStates;
-  if (!ignoredStates) {
+  if (!ignoredStates || !data.SPA_ID) {
     return false;
   }
   const testStatesList: string[] = [];

--- a/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
+++ b/src/services/compare-appian/handlers/utils/getIsIgnoredState.ts
@@ -4,7 +4,7 @@ export const getIsIgnoredState = (
   data: Types.AppianReportData | Types.ReportData
 ) => {
   const ignoredStates = process.env.ignoredStates;
-  if (!ignoredStates || !data.SPA_ID) {
+  if (!ignoredStates) {
     return false;
   }
   const testStatesList: string[] = [];
@@ -12,7 +12,11 @@ export const getIsIgnoredState = (
     .split(",")
     .forEach((state: string) => testStatesList.push(state));
   const isIgnoredState =
-    testStatesList.indexOf(data.SPA_ID.slice(0, 2).toUpperCase()) > -1;
+    testStatesList.indexOf(
+      data.SPA_ID
+        ? data.SPA_ID.slice(0, 2).toUpperCase()
+        : data.SPA_PCKG_ID.slice(0, 2).toUpperCase()
+    ) > -1;
   if (isIgnoredState) {
     console.log("IGNORED STATE - NO ALERTS WILL BE SENT");
     return true;

--- a/src/types/appian/interfaces.ts
+++ b/src/types/appian/interfaces.ts
@@ -68,10 +68,10 @@ export interface ReportData extends AppianFormField {
 }
 
 export interface CSVData {
-  "SPA ID"?: string;
-  "Submission Date"?: string;
-  "Seatool Record Exist"?: boolean;
-  "Seatool Signed Date"?: string;
+  "SPA ID": string;
+  "Submission Date": string;
+  "Seatool Record Exist": boolean;
+  "Seatool Signed Date": string;
 }
 
 export interface AppianSeatoolCompareData {

--- a/src/types/appian/interfaces.ts
+++ b/src/types/appian/interfaces.ts
@@ -68,10 +68,10 @@ export interface ReportData extends AppianFormField {
 }
 
 export interface CSVData {
-  "SPA ID": string;
-  "Submission Date": string;
-  "Seatool Record Exist": boolean;
-  "Seatool Signed Date": string;
+  "SPA ID"?: string;
+  "Submission Date"?: string;
+  "Seatool Record Exist"?: boolean;
+  "Seatool Signed Date"?: string;
 }
 
 export interface AppianSeatoolCompareData {

--- a/src/types/appian/interfaces.ts
+++ b/src/types/appian/interfaces.ts
@@ -79,6 +79,7 @@ export interface AppianSeatoolCompareData {
   PK: string;
   SK: string;
   SPA_ID: string;
+  SPA_PCKG_ID: string;
   secSinceAppianSubmitted: number;
   isAppianInSubmittedStatus: boolean;
   appianSubmittedDate: number;
@@ -90,6 +91,7 @@ export interface AppianReportData {
   SK: string;
   isAppianInSubmittedStatus: boolean;
   SPA_ID: string;
+  SPA_PCKG_ID: string;
   secSinceAppianSubmitted: number;
   appianSubmittedDate: number;
   seatoolExist: boolean;


### PR DESCRIPTION
## Purpose
Fixed an issue when appian reporting is null. In all environments the sendReport function fails when SPA_ID is null because there is a data.SPA_ID check in the getIsIgnoredState function.
