### PR TITLE
docs(compare): align local Node version with runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For accessing private repositories and packages:
 ## Local Development
 
 ### Prerequisites
-- Node.js v20.17.0
+- Node.js v22.x
 - Yarn v1.22.19 or later
 - AWS CLI v2
 - AWS SSO configured


### PR DESCRIPTION
Update the README to reflect the Node 22 runtime already used by the deployed Lambdas.

CLDSPT-102506
